### PR TITLE
fix `vite-plugin-admin-dashboard` for windows machines

### DIFF
--- a/.changeset/flat-lions-compare.md
+++ b/.changeset/flat-lions-compare.md
@@ -1,0 +1,5 @@
+---
+"astro-netlify-cms": patch
+---
+
+remove node join() from vite-plugin-admin-dashboard to allow windows to run dev

--- a/integration/vite-plugin-admin-dashboard.ts
+++ b/integration/vite-plugin-admin-dashboard.ts
@@ -14,7 +14,6 @@ const AdminPage = ({
   adminPath: string;
   config: CmsConfig;
   previewStyles: Array<string | [string] | [string, { raw: boolean }]>;
-  projectRoot: string;
 } & (
   | { assets: [id: string, filename: string][]; dashboardPath?: undefined }
   | { assets?: undefined; dashboardPath: string }
@@ -88,15 +87,10 @@ export default function AdminDashboardPlugin({
     adminPath = adminPath.slice(0, -1);
   }
 
-  let projectRoot: string;
   let importMap: ImportMap;
 
   return {
     name: 'vite-plugin-netlify-cms-admin-dashboard',
-
-    configResolved({ root }) {
-      projectRoot = root;
-    },
 
     options(options) {
       let { input } = options;
@@ -109,7 +103,6 @@ export default function AdminDashboardPlugin({
         importMap = generateImportMap({
           dashboardPath,
           previewStyles,
-          projectRoot,
         });
         input = { ...input, ...importMap };
       }
@@ -126,7 +119,6 @@ export default function AdminDashboardPlugin({
               config,
               dashboardPath,
               previewStyles,
-              projectRoot,
             })
           );
           res.end(adminPage);
@@ -149,7 +141,6 @@ export default function AdminDashboardPlugin({
           assets: collectBundleAssets(bundle, importMap),
           config,
           previewStyles,
-          projectRoot,
         }),
       });
     },
@@ -177,7 +168,6 @@ function generateImportMap({
 }: {
   dashboardPath: string;
   previewStyles: Array<string | [string] | [string, { raw: boolean }]>;
-  projectRoot: string;
 }): ImportMap {
   const imports: ImportMap = { cms: dashboardPath };
   previewStyles.forEach((entry, index) => {

--- a/integration/vite-plugin-admin-dashboard.ts
+++ b/integration/vite-plugin-admin-dashboard.ts
@@ -1,7 +1,6 @@
 import type { CmsConfig } from 'netlify-cms-core';
 import type { OutputBundle } from 'rollup';
 import type { Plugin } from 'vite';
-import { join } from 'node:path';
 
 const dashboardPath = 'astro-netlify-cms/cms';
 
@@ -11,7 +10,6 @@ const AdminPage = ({
   config,
   dashboardPath,
   previewStyles = [],
-  projectRoot,
 }: {
   adminPath: string;
   config: CmsConfig;
@@ -176,7 +174,6 @@ interface ImportMap {
 function generateImportMap({
   dashboardPath,
   previewStyles,
-  projectRoot,
 }: {
   dashboardPath: string;
   previewStyles: Array<string | [string] | [string, { raw: boolean }]>;

--- a/integration/vite-plugin-admin-dashboard.ts
+++ b/integration/vite-plugin-admin-dashboard.ts
@@ -187,7 +187,7 @@ function generateImportMap({
     if (!Array.isArray(entry)) entry = [entry];
     const [style, opts] = entry;
     if (opts?.raw || style.startsWith('http')) return;
-    imports[`style__${index}`] = join(projectRoot, style);
+    imports[`style__${index}`] = style;
   });
   return imports;
 }

--- a/integration/vite-plugin-admin-dashboard.ts
+++ b/integration/vite-plugin-admin-dashboard.ts
@@ -44,7 +44,7 @@ const AdminPage = ({
       styles.push(JSON.stringify([style, opts]));
     } else if (!assets) {
       const name = `style__${index}`;
-      imports.push(`import ${name} from '${join(projectRoot, style)}';`);
+      imports.push(`import ${name} from '/${style}';`);
       styles.push(`[${name}, { raw: true }]`);
     }
   });

--- a/integration/vite-plugin-admin-dashboard.ts
+++ b/integration/vite-plugin-admin-dashboard.ts
@@ -187,7 +187,7 @@ function generateImportMap({
     if (!Array.isArray(entry)) entry = [entry];
     const [style, opts] = entry;
     if (opts?.raw || style.startsWith('http')) return;
-    imports[`style__${index}`] = style;
+    imports[`style__${index}`] = `/${style}`;
   });
   return imports;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "astro-netlify-cms",
-  "version": "0.2.0",
+  "version": "0.2.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "astro-netlify-cms",
-      "version": "0.2.0",
+      "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
         "@astrojs/react": "^1.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "astro-netlify-cms",
-  "version": "0.2.2",
+  "version": "0.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "astro-netlify-cms",
-      "version": "0.2.2",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@astrojs/react": "^1.1.1",


### PR DESCRIPTION
admin dashboard did not run on windows machines, per [this issue](https://github.com/delucis/astro-netlify-cms-starter/issues/2)

to fix this, I removed both instances of node `join()` and `projectRoot` and replace it with a simple forward slash.

tested `npm run dev` and `npm run build` on both powershell 7 and wsl ubuntu 20.04