### PR TITLE
Use `injectRoute` to inject admin dashboard

### DIFF
--- a/.changeset/cold-olives-prove.md
+++ b/.changeset/cold-olives-prove.md
@@ -1,0 +1,7 @@
+---
+'astro-netlify-cms': minor
+---
+
+Refactor to use Astro’s built-in `injectRoute` helper to add the admin dashboard.
+
+Significantly simplifies the Vite plugin logic and should make future improvements easier to implement.

--- a/admin-dashboard.astro
+++ b/admin-dashboard.astro
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>Content Manager</title>
+    <meta
+      name="description"
+      content="Admin dashboard for managing website content"
+    />
+    <script>
+      import options from 'virtual:astro-netlify-cms/user-config';
+      import initCMS from './dist/cms';
+      initCMS(options);
+    </script>
+  </head>
+  <body></body>
+</html>

--- a/integration/cms.ts
+++ b/integration/cms.ts
@@ -1,38 +1,16 @@
-import type { CmsField, CmsConfig } from 'netlify-cms-core';
-import CMS from 'netlify-cms-app';
-import { initIdentity } from './identity-widget';
-import type { NormalizedPreviewStyle } from './types';
+import { InitCmsOptions } from './types';
 
 export default function initCMS({
-  adminPath,
+  cms,
   config,
-  components = {},
   previewStyles = [],
-}: {
-  adminPath: string;
-  config: CmsConfig;
-  // collections: {
-  //   component;
-  //   css: string;
-  //   collection: CmsCollection;
-  // }[];
-  components: Record<
-    string,
-    {
-      component: React.ComponentType<any>;
-      fields: (CmsField & { name: keyof any })[];
-    }
-  >;
-  previewStyles: NormalizedPreviewStyle[];
-}) {
-  initIdentity(adminPath);
-
+}: InitCmsOptions) {
   // Provide default values given we can make a reasonable guess
   const mediaDefaults = !config.media_folder
     ? { media_folder: 'public', public_folder: '/' }
     : {};
 
-  CMS.init({
+  cms.init({
     config: {
       // Don’t try to load config.yml as we’re providing the config below
       load_config_file: false,
@@ -44,97 +22,15 @@ export default function initCMS({
   });
 
   /**
-   * Another drawback of using Netlify CMS is that it registers all preview
+   * One drawback of using Netlify CMS is that it registers all preview
    * styles globally — not scoped to a specific collection.
-   * You’ve lost Astro component’s scoped styling anyway by being forced
+   * You lose Astro components’ scoped styling anyway by being forced
    * to use React, but just be extra careful.
    *
    * The (undocumented?) `raw: true` setting treats the first argument as
    * a raw CSS string to inject instead of as a URL to load a stylesheet from.
    */
   previewStyles.forEach(([style, opts]) =>
-    CMS.registerPreviewStyle(style, opts)
+    cms.registerPreviewStyle(style, opts)
   );
-
-  /**
-   * Register each of our collections’ preview styles and components.
-   */
-  // collections.forEach(({ component, collection }) => {
-  //   CMS.registerPreviewTemplate(
-  //     collection.name,
-  //     ({ entry, widgetFor, getAsset }) => {
-  //       // Netlify CMS gives us an Immutable.js object for entry data.
-  //       // Here we convert this into a plain JS object.
-  //       const props = entry.get('data').toJS();
-
-  //       // Some data types need extra work before passing them to the component.
-  //       collection.fields.forEach(({ name, widget }) => {
-  //         switch (widget) {
-  //           // Images can be in-memory before they’re uploaded, so we use the
-  //           // `getAsset` helper to get a useable source URL.
-  //           case 'image':
-  //             props[name] = props[name] && getAsset(props[name]).toString();
-  //             break;
-  //           // The `widgetFor` helper hands us rendered Markdown content.
-  //           // We also map fields named `body` to `children` props.
-  //           case 'markdown':
-  //             props[name === 'body' ? 'children' : name] = widgetFor(name);
-  //             break;
-  //         }
-  //       });
-
-  //       return component(props);
-  //     }
-  //   );
-  // });
-
-  /**
-   * Below implements the infrastructure for custom components in the Markdown
-   * editor.
-   *
-   * Caveats:
-   *   - Components MUST be block-level rather than inline
-   *   - Accessing `frontmatter` is not supported.
-   *   - Components MUST be imported in a post’s `setup` front matter.
-   *     The default value for the hidden `setup` field above does this, but
-   *     can’t update the value if new components are added after a post is
-   *     created.
-   *   - No `client:...` directive support yet. This should be do-able, just
-   *     needs some more RegExp wrangling.
-   *   - Attributes *must* be strings for now. Should be possible to support
-   *     other data types eventually to some degree.
-   */
-
-  // for (const Name in components) {
-  //   const { component, fields } = components[Name];
-  //   CMS.registerEditorComponent({
-  //     id: Name,
-  //     label: Name,
-  //     fields,
-  //     pattern: new RegExp(`^<${Name} (.*?)/>$`),
-  //     fromBlock: (match) =>
-  //       match[1]
-  //         .split('" ')
-  //         .map((attr) => attr.split('="'))
-  //         .reduce((attrs, [attr, val]) => ({ ...attrs, [attr]: val }), {}),
-  //     toBlock: (obj) => {
-  //       const attrs = Object.entries(obj)
-  //         .map(([attr, val]) => `${attr}="${val}"`)
-  //         .join(' ');
-  //       return `<${Name} ${attrs} />`;
-  //     },
-  //     toPreview: component,
-  //   });
-  // }
-
-  /**
-   * Things that would be nice but are currently impossible:
-   *
-   * - Expression syntax:
-   *   i. Netlify CMS doesn’t support creating custom inline widgets.
-   *   ii. Even for a custom block widget, Netlify CMS won’t provide
-   *      `frontmatter`, so you’re limited to plain JS, like `{5 * 2}`,
-   *      which is not very useful. (Obviously Astro APIs are also
-   *      not available in the browser.)
-   */
 }

--- a/integration/types.ts
+++ b/integration/types.ts
@@ -1,5 +1,14 @@
+import type CMS from 'netlify-cms-app';
+import type { CmsConfig } from 'netlify-cms-core';
+
 export type NormalizedPreviewStyle =
   | [pathOrUrl: string]
   | [rawCSS: string, meta: { raw: boolean }];
 
 export type PreviewStyle = string | NormalizedPreviewStyle;
+
+export interface InitCmsOptions {
+  cms: typeof CMS;
+  config: CmsConfig;
+  previewStyles?: NormalizedPreviewStyle[];
+}

--- a/integration/virtual.d.ts
+++ b/integration/virtual.d.ts
@@ -1,0 +1,5 @@
+declare module 'virtual:astro-netlify-cms/user-config' {
+  import type { InitCmsOptions } from './types';
+  const CmsOptions: InitCmsOptions;
+  export default CmsOptions;
+}

--- a/integration/vite-plugin-admin-dashboard.ts
+++ b/integration/vite-plugin-admin-dashboard.ts
@@ -1,209 +1,59 @@
 import type { CmsConfig } from 'netlify-cms-core';
-import type { OutputBundle } from 'rollup';
 import type { Plugin } from 'vite';
 import type { PreviewStyle } from './types';
 
-const dashboardPath = 'astro-netlify-cms/cms';
+const virtualModuleId = 'virtual:astro-netlify-cms/user-config';
+const resolvedVirtualModuleId = '\0' + virtualModuleId;
 
-function AdminPage({
-  adminPath,
-  assets,
+function generateVirtualConfigModule({
   config,
   previewStyles = [],
 }: {
-  adminPath: string;
   config: CmsConfig;
   previewStyles: Array<string | [string] | [string, { raw: boolean }]>;
-  /** Array of module ID and filename tuples present only at build time. */
-  assets?: [id: string, filename: string][];
 }) {
   const imports: string[] = [];
   const styles: string[] = [];
-
-  if (assets) {
-    for (const [name, filename] of assets) {
-      // At build time, pass the path of built styles straight to Netlify CMS.
-      if (name.startsWith('style__')) {
-        styles.push(`['/${filename}']`);
-      } else {
-        imports.push(`import ${name} from '/${filename}';`);
-      }
-    }
-  } else {
-    imports.push(`import cms from '${dashboardPath}';`);
-  }
 
   previewStyles.forEach((entry, index) => {
     if (!Array.isArray(entry)) entry = [entry];
     const [style, opts] = entry;
     if (opts?.raw || style.startsWith('http')) {
       styles.push(JSON.stringify([style, opts]));
-    } else if (!assets) {
+    } else {
       const name = `style__${index}`;
-      imports.push(`import ${name} from '/${style}';`);
+      imports.push(`import ${name} from '/${style}?raw';`);
       styles.push(`[${name}, { raw: true }]`);
     }
   });
 
-  return `<html lang="en">
-  <head>
-  <title>Content Manager</title>
-  <meta
-  name="description"
-  content="Admin dashboard for managing website content"
-  />
-  <script type="module">
-  ${imports.join('\n')}
-  cms({
-    adminPath: '${adminPath}',
-    config: JSON.parse('${JSON.stringify(config)}'),
-    previewStyles: [${styles.join(',')}],
-  });
-  </script>
-  </head>
-  <body></body>
-  </html>
-  `;
+  return `${imports.join('\n')}
+import * as NCMS from 'netlify-cms-app';
+export default {
+  cms: NCMS,
+  config: JSON.parse('${JSON.stringify(config)}'),
+  previewStyles: [${styles.join(',')}],
+};
+`;
 }
 
 export default function AdminDashboardPlugin({
-  adminPath,
   config,
   previewStyles,
 }: {
-  adminPath: string;
   config: Omit<CmsConfig, 'load_config_file' | 'local_backend'>;
   previewStyles: PreviewStyle[];
 }): Plugin {
-  if (!adminPath.startsWith('/')) {
-    throw new Error(
-      '`adminPath` option must be a root-relative pathname, starting with "/", got "' +
-        adminPath +
-        '"'
-    );
-  }
-  if (adminPath.endsWith('/')) {
-    adminPath = adminPath.slice(0, -1);
-  }
-
-  let importMap: ImportMap;
-
   return {
     name: 'vite-plugin-netlify-cms-admin-dashboard',
 
-    /** Build-only Rollup hook. */
-    options(options) {
-      let { input } = options;
-      if (
-        input &&
-        (!Array.isArray(input) ||
-          !input.includes('@astrojs-pages-virtual-entry'))
-      ) {
-        if (!Array.isArray(input) && typeof input !== 'object') input = [input];
-        importMap = generateImportMap({
-          previewStyles,
-        });
-        input = { ...input, ...importMap };
-      }
-      return { ...options, input };
+    resolveId(id) {
+      if (id === virtualModuleId) return resolvedVirtualModuleId;
     },
 
-    /** Dev-only Vite hook. */
-    configureServer({ transformIndexHtml, middlewares }) {
-      middlewares.use(async (req, res, next) => {
-        if (req.url === adminPath || req.url === adminPath + '/') {
-          const adminPage = await transformIndexHtml(
-            adminPath,
-            AdminPage({
-              adminPath,
-              config,
-              previewStyles,
-            })
-          );
-          res.end(adminPage);
-        } else {
-          next();
-        }
-      });
-    },
-
-    /** Build-only Rollup hook. */
-    generateBundle(options, bundle) {
-      const dashboardChunk = Object.values(bundle).find(
-        ({ name }) => name === 'cms'
-      );
-      if (!dashboardChunk) return;
-      this.emitFile({
-        type: 'asset',
-        fileName: adminPath.replace(/((^\/)|(\/$))/g, '') + '/index.html',
-        source: AdminPage({
-          adminPath,
-          assets: collectBundleAssets(bundle, importMap),
-          config,
-          previewStyles,
-        }),
-      });
+    load(id) {
+      if (id === resolvedVirtualModuleId)
+        return generateVirtualConfigModule({ config, previewStyles });
     },
   };
-}
-
-interface ImportMap {
-  cms: string;
-  [id: `style__${number}`]: string;
-}
-
-/**
- * Generate a map of asset IDs to paths where they can be imported.
- * @returns An object like:
- * ```js
- * {
- *   cms: 'astro-netlify-cms/cms.ts',
- *   style__0: '/path/to/project/dir/path/to/style.css',
- * }
- * ```
- */
-function generateImportMap({
-  previewStyles,
-}: {
-  previewStyles: Array<string | [string] | [string, { raw: boolean }]>;
-}): ImportMap {
-  const imports: ImportMap = { cms: dashboardPath };
-  previewStyles.forEach((entry, index) => {
-    if (!Array.isArray(entry)) entry = [entry];
-    const [style, opts] = entry;
-    if (opts?.raw || style.startsWith('http')) return;
-    imports[`style__${index}`] = `/${style}`;
-  });
-  return imports;
-}
-
-/**
- * Extract assets defined in the import map from Rollup’s bundle.
- */
-function collectBundleAssets(
-  bundle: OutputBundle,
-  importMap: ImportMap
-): [id: string, filename: string][] {
-  const stripExtension = (filename: string) => filename.split('.')[0];
-  /** Map of module paths to module IDs like `{ 'src/styles/blog.css': 'style__1', ... }` */
-  const importTargets = new Map<string, string>(
-    Object.entries(importMap).map(([id, target]) => [
-      target.replace(/^\//, ''), // strip leading slash
-      id,
-    ])
-  );
-
-  return Object.values(bundle)
-    .filter(({ name, fileName }) => {
-      return (
-        !!name &&
-        (stripExtension(name) in importMap || importTargets.has(name)) &&
-        // Filter out non-CSS `style__` assets (a tiny JS file seems to get built for each)
-        (!name.startsWith('style__') || fileName.endsWith('.css'))
-      );
-    })
-    .map(({ name, fileName }) => [
-      importTargets.get(name) || stripExtension(name!),
-      fileName,
-    ]);
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     ".": "./dist/index.js",
     "./cms": "./dist/cms.js",
     "./identity-widget": "./dist/identity-widget.js",
-    "./vite-plugin-admin-dashboard": "./dist/vite-plugin-admin-dashboard.js"
+    "./vite-plugin-admin-dashboard": "./dist/vite-plugin-admin-dashboard.js",
+    "./admin-dashboard.astro": "./admin-dashboard.astro"
   },
   "types": "./dist/index.d.ts",
   "scripts": {


### PR DESCRIPTION
This PR heavily refactors the integration to make use of Astro’s built-in `injectRoute` helper instead of the flaky, hand-rolled page injection logic we were using up until now (which dated to before `injectRoute`’s existence).

This significantly simplifies things and should make future improvements easier to implement.
