### PR TITLE
Fix an issue in some browsers with the Markdown widget

### DIFF
--- a/.changeset/swift-feet-play.md
+++ b/.changeset/swift-feet-play.md
@@ -1,0 +1,7 @@
+---
+"astro-netlify-cms": patch
+---
+
+Fix an issue in some browsers with the rich text editor.
+
+Adds the workaround documented in [netlify/netlify-cms#5092](https://github.com/netlify/netlify-cms/issues/5092) to the admin dashboard.

--- a/admin-dashboard.astro
+++ b/admin-dashboard.astro
@@ -11,6 +11,12 @@
       import initCMS from './dist/cms';
       initCMS(options);
     </script>
+    <style is:global>
+      /* Workaround for https://github.com/netlify/netlify-cms/issues/5092 */
+      [data-slate-editor] {
+        -webkit-user-modify: read-write !important;
+      }
+    </style>
   </head>
   <body></body>
 </html>


### PR DESCRIPTION
In some browsers, the text cursor in the Markdown editor widget can jump while typing in certain circumstances, making it more or less impossible to use. This was reported in https://github.com/netlify/netlify-cms/issues/5092 which also documents a workaround. This commit adds the workaround to the admin dashboard so we can benefit from it by default.