### PR TITLE
Restart Netlify CMS proxy server on astro.config reload

### DIFF
--- a/.changeset/sixty-carpets-reflect.md
+++ b/.changeset/sixty-carpets-reflect.md
@@ -1,0 +1,5 @@
+---
+"astro-netlify-cms": patch
+---
+
+Restart Netlify CMS proxy server when astro.config reloads

--- a/integration/index.ts
+++ b/integration/index.ts
@@ -35,6 +35,8 @@ export default function NetlifyCMS({
     adminPath = adminPath.slice(0, -1);
   }
 
+  let proxy: ReturnType<typeof spawn>;
+
   const NetlifyCMSIntegration: AstroIntegration = {
     name: 'netlify-cms',
     hooks: {
@@ -73,12 +75,16 @@ export default function NetlifyCMS({
       },
 
       'astro:server:start': () => {
-        const proxy = spawn('netlify-cms-proxy-server', {
+        proxy = spawn('netlify-cms-proxy-server', {
           stdio: 'inherit',
           // Run in shell on Windows to make sure the npm package can be found.
           shell: process.platform === 'win32',
         });
         process.on('exit', () => proxy.kill());
+      },
+
+      'astro:server:done': () => {
+        proxy.kill();
       },
     },
   };


### PR DESCRIPTION
When astro.config is saved, Astro automatically reloads, which caused a second instance of `netlify-cms-proxy-server` to try to start and crash. This fix ensures we kill and restart the proxy server instead each time this happens.