### PR TITLE
`disableIdentityWidgetInjection` — inject identity widget to admin

### DIFF
--- a/.changeset/strong-icons-sort.md
+++ b/.changeset/strong-icons-sort.md
@@ -1,0 +1,5 @@
+---
+"astro-netlify-cms": patch
+---
+
+Include identity widget on admin route even when `disableIdentityWidgetInjection` is set to `true`

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ previewStyles: [
 **Type:** `boolean`  
 **Default:** `false`
 
-By default, `astro-netlify-cms` injects Netlify’s [Identity Widget](https://github.com/netlify/netlify-identity-widget) across your site to enable authentication. If you are handling this in some other way, you can disable this by setting `disableIdentityWidgetInjection: true`.
+By default, `astro-netlify-cms` injects Netlify’s [Identity Widget](https://github.com/netlify/netlify-identity-widget) across your site to enable authentication. If you only want to inject the widget on the admin route, you can set `disableIdentityWidgetInjection: true`.
 
 ## To-do
 

--- a/integration/index.ts
+++ b/integration/index.ts
@@ -46,6 +46,7 @@ export default function NetlifyCMS({
         injectScript,
         updateConfig,
       }) => {
+        const identityWidgetScript = `import { initIdentity } from '${widgetPath}'; initIdentity('${adminPath}');`;
         const newConfig: AstroUserConfig = {
           // Default to the URL provided by Netlify when building there. See:
           // https://docs.netlify.com/configure-builds/environment-variables/#deploy-urls-and-metadata
@@ -56,6 +57,9 @@ export default function NetlifyCMS({
               AdminDashboard({
                 config: cmsConfig,
                 previewStyles,
+                identityWidget: disableIdentityWidgetInjection
+                  ? identityWidgetScript
+                  : '',
               }),
             ],
           },
@@ -66,11 +70,9 @@ export default function NetlifyCMS({
           pattern: adminPath,
           entryPoint: 'astro-netlify-cms/admin-dashboard.astro',
         });
+
         if (!disableIdentityWidgetInjection) {
-          injectScript(
-            'page',
-            `import { initIdentity } from '${widgetPath}'; initIdentity('${adminPath}')`
-          );
+          injectScript('page', identityWidgetScript);
         }
       },
 

--- a/integration/vite-plugin-admin-dashboard.ts
+++ b/integration/vite-plugin-admin-dashboard.ts
@@ -8,9 +8,11 @@ const resolvedVirtualModuleId = '\0' + virtualModuleId;
 function generateVirtualConfigModule({
   config,
   previewStyles = [],
+  identityWidget,
 }: {
   config: CmsConfig;
   previewStyles: Array<string | [string] | [string, { raw: boolean }]>;
+  identityWidget: string;
 }) {
   const imports: string[] = [];
   const styles: string[] = [];
@@ -29,6 +31,7 @@ function generateVirtualConfigModule({
 
   return `${imports.join('\n')}
 import * as NCMS from 'netlify-cms-app';
+${identityWidget}
 export default {
   cms: NCMS,
   config: JSON.parse('${JSON.stringify(config)}'),
@@ -40,9 +43,11 @@ export default {
 export default function AdminDashboardPlugin({
   config,
   previewStyles,
+  identityWidget,
 }: {
   config: Omit<CmsConfig, 'load_config_file' | 'local_backend'>;
   previewStyles: PreviewStyle[];
+  identityWidget: string;
 }): Plugin {
   return {
     name: 'vite-plugin-netlify-cms-admin-dashboard',
@@ -53,7 +58,11 @@ export default function AdminDashboardPlugin({
 
     load(id) {
       if (id === resolvedVirtualModuleId)
-        return generateVirtualConfigModule({ config, previewStyles });
+        return generateVirtualConfigModule({
+          config,
+          previewStyles,
+          identityWidget,
+        });
     },
   };
 }


### PR DESCRIPTION
After some manual tests it turns out you do always want the Netlify Identity widget on the admin route. This PR changes how the `disableIdentityWidgetInjection` option works: it now disables site-wide injection but still injects the widget as part of the admin dashboard.

Closes #40 