### PR TITLE
Don’t automatically inject `@astrojs/react` integration

### DIFF
--- a/.changeset/two-lobsters-sit.md
+++ b/.changeset/two-lobsters-sit.md
@@ -1,0 +1,15 @@
+---
+'astro-netlify-cms': minor
+---
+
+Don’t automatically inject `@astrojs/react` integration
+
+⚠️ BREAKING CHANGE ⚠️
+
+Previously, this integration included [`@astrojs/react`](https://docs.astro.build/en/guides/integrations-guide/react/) and injected it to Astro’s integrations config for you. This is no longer the case.
+
+If you are using React components and were relying on this, make sure to add the integration when upgrading. The simplest way to do this is to run:
+
+```bash
+npx astro add react
+```

--- a/integration/index.ts
+++ b/integration/index.ts
@@ -1,9 +1,8 @@
 import type { AstroIntegration, AstroUserConfig } from 'astro';
 import type { CmsConfig } from 'netlify-cms-core';
 import { spawn } from 'node:child_process';
-import react from '@astrojs/react';
-import AdminDashboard from './vite-plugin-admin-dashboard.js';
 import type { PreviewStyle } from './types.js';
+import AdminDashboard from './vite-plugin-admin-dashboard.js';
 
 const widgetPath = 'astro-netlify-cms/identity-widget';
 
@@ -90,5 +89,5 @@ export default function NetlifyCMS({
       },
     },
   };
-  return [react(), NetlifyCMSIntegration];
+  return NetlifyCMSIntegration;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,14 @@
 {
   "name": "astro-netlify-cms",
-  "version": "0.3.4",
+  "version": "0.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "astro-netlify-cms",
-      "version": "0.3.4",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
-        "@astrojs/react": "^1.2.1",
         "@types/react": "^17.0.50",
         "netlify-cms-app": "^2.15.66",
         "netlify-cms-proxy-server": "^1.3.23",
@@ -879,24 +878,6 @@
         "node": "^14.18.0 || >=16.12.0"
       }
     },
-    "node_modules/@astrojs/react": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@astrojs/react/-/react-1.2.1.tgz",
-      "integrity": "sha512-EoW7coV/35ak1fPoVNrL1OyYGOnJSnRJsgIc8WtkLv5aDrMpviS6+9vmqOHEiJwab8wNh+zSphx8a9nC2Q3zAg==",
-      "dependencies": {
-        "@babel/core": ">=7.0.0-0 <8.0.0",
-        "@babel/plugin-transform-react-jsx": "^7.17.12"
-      },
-      "engines": {
-        "node": "^14.18.0 || >=16.12.0"
-      },
-      "peerDependencies": {
-        "@types/react": "^17.0.50 || ^18.0.21",
-        "@types/react-dom": "^17.0.17 || ^18.0.6",
-        "react": "^17.0.2 || ^18.0.0",
-        "react-dom": "^17.0.2 || ^18.0.0"
-      }
-    },
     "node_modules/@astrojs/telemetry": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@astrojs/telemetry/-/telemetry-1.0.1.tgz",
@@ -1059,6 +1040,7 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.18.6.tgz",
       "integrity": "sha512-duORpUiYrEpzKIop6iNbjnwKLAKnJ47csTyRACyEmWj0QdUrm5aqNJGHSSEQSUAvNW0ojX0dOmK9dZduvkfeXA==",
+      "dev": true,
       "dependencies": {
         "@babel/types": "^7.18.6"
       },
@@ -1252,6 +1234,7 @@
       "version": "7.18.10",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.18.10.tgz",
       "integrity": "sha512-gCy7Iikrpu3IZjYZolFE4M1Sm+nrh1/6za2Ewj77Z+XirT4TsbJcvOFOyF+fRPwU6AKKK136CZxx6L8AbSFG6A==",
+      "dev": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.18.6",
         "@babel/helper-module-imports": "^7.18.6",
@@ -2593,15 +2576,6 @@
         "@types/prop-types": "*",
         "@types/scheduler": "*",
         "csstype": "^3.0.2"
-      }
-    },
-    "node_modules/@types/react-dom": {
-      "version": "18.0.6",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.6.tgz",
-      "integrity": "sha512-/5OFZgfIPSwy+YuIBP/FgJnQnsxhZhjjrnxudMddeblOouIodEQ75X14Rr4wGSG/bknL+Omy9iWlLo1u/9GzAA==",
-      "peer": true,
-      "dependencies": {
-        "@types/react": "*"
       }
     },
     "node_modules/@types/react-redux": {
@@ -16410,15 +16384,6 @@
         "prismjs": "^1.28.0"
       }
     },
-    "@astrojs/react": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@astrojs/react/-/react-1.2.1.tgz",
-      "integrity": "sha512-EoW7coV/35ak1fPoVNrL1OyYGOnJSnRJsgIc8WtkLv5aDrMpviS6+9vmqOHEiJwab8wNh+zSphx8a9nC2Q3zAg==",
-      "requires": {
-        "@babel/core": ">=7.0.0-0 <8.0.0",
-        "@babel/plugin-transform-react-jsx": "^7.17.12"
-      }
-    },
     "@astrojs/telemetry": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@astrojs/telemetry/-/telemetry-1.0.1.tgz",
@@ -16543,6 +16508,7 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.18.6.tgz",
       "integrity": "sha512-duORpUiYrEpzKIop6iNbjnwKLAKnJ47csTyRACyEmWj0QdUrm5aqNJGHSSEQSUAvNW0ojX0dOmK9dZduvkfeXA==",
+      "dev": true,
       "requires": {
         "@babel/types": "^7.18.6"
       }
@@ -16676,6 +16642,7 @@
       "version": "7.18.10",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.18.10.tgz",
       "integrity": "sha512-gCy7Iikrpu3IZjYZolFE4M1Sm+nrh1/6za2Ewj77Z+XirT4TsbJcvOFOyF+fRPwU6AKKK136CZxx6L8AbSFG6A==",
+      "dev": true,
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.18.6",
         "@babel/helper-module-imports": "^7.18.6",
@@ -17859,15 +17826,6 @@
           "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.0.tgz",
           "integrity": "sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA=="
         }
-      }
-    },
-    "@types/react-dom": {
-      "version": "18.0.6",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.6.tgz",
-      "integrity": "sha512-/5OFZgfIPSwy+YuIBP/FgJnQnsxhZhjjrnxudMddeblOouIodEQ75X14Rr4wGSG/bknL+Omy9iWlLo1u/9GzAA==",
-      "peer": true,
-      "requires": {
-        "@types/react": "*"
       }
     },
     "@types/react-redux": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "netlify-cms"
   ],
   "dependencies": {
-    "@astrojs/react": "^1.2.1",
     "@types/react": "^17.0.50",
     "netlify-cms-app": "^2.15.66",
     "netlify-cms-proxy-server": "^1.3.23",


### PR DESCRIPTION
Closes #51
Closes #52

⚠️ BREAKING CHANGE ⚠️

Previously, this integration included [`@astrojs/react`](https://docs.astro.build/en/guides/integrations-guide/react/) and injected it to Astro’s integrations config for you. This is no longer the case.

If you are using React components and were relying on this, make sure to add the integration when upgrading. The simplest way to do this is to run:

```bash
npx astro add react
```